### PR TITLE
solving apps/r dependencies

### DIFF
--- a/cluster/prometheus.bash
+++ b/cluster/prometheus.bash
@@ -13,7 +13,7 @@ function RUN_GPU_CHECK {
 	case "$RUN_GPU" in
 	y)
 		MAINQ_DEF="plgrid-gpu"
-		MODULES_RUN_DEF="apps/cuda/9.0 tools/openmpi/2.0.1-gcc-4.9.2"
+		MODULES_RUN_DEF="tools/openmpi/2.0.1-gcc-4.9.2"
 		CONFOPT_DEF="--with-cuda-arch=sm_30"
 		MAX_UNITS_PER_NODE_DEF=2
 		CORES_PER_UNIT_DEF=1
@@ -40,6 +40,11 @@ function RUN_GPU_CHECK {
 	return 0
 }
 MAINQ_ASK="no"
-MODULES_ADD_DEF="apps/r"
+
+MODULES_ADD_DEF="apps/r"  
+# Prometheus's module apps/r loads apps/cuda/9.0 as dependency. 
+# Moreover apps/r loads tools/gcc/6.4.0 which causes conflict with openmpi/2.0.1-gcc-4.9.2, 
+# thus apps/r (with its dependencies) must be called first $MODULES_ADD, then override with $MODULES_RUN
+
 MODULES_ADD_ASK="no"
 MODULES_RUN_ASK="no"

--- a/cluster/prometheus.bash
+++ b/cluster/prometheus.bash
@@ -13,7 +13,7 @@ function RUN_GPU_CHECK {
 	case "$RUN_GPU" in
 	y)
 		MAINQ_DEF="plgrid-gpu"
-		MODULES_RUN_DEF="tools/openmpi/2.0.1-gcc-4.9.2"
+		MODULES_RUN_DEF="plgrid/apps/cuda/9.0 tools/openmpi/2.1.1-gcc-6.4.0"
 		CONFOPT_DEF="--with-cuda-arch=sm_30"
 		MAX_UNITS_PER_NODE_DEF=2
 		CORES_PER_UNIT_DEF=1
@@ -24,7 +24,7 @@ function RUN_GPU_CHECK {
 		;;
 	n)
 		MAINQ_DEF="plgrid"
-		MODULES_RUN_DEF="tools/openmpi/2.0.1-gcc-4.9.2"
+		MODULES_RUN_DEF="tools/openmpi/2.1.1-gcc-6.4.0"
 		CONFOPT_DEF="--disable-cuda"
 		MAX_UNITS_PER_NODE_DEF=12
 		CORES_PER_UNIT_DEF=1
@@ -41,10 +41,9 @@ function RUN_GPU_CHECK {
 }
 MAINQ_ASK="no"
 
-MODULES_ADD_DEF="apps/r"  
+MODULES_ADD_DEF="apps/r/3.4.4"  
 # Prometheus's module apps/r loads apps/cuda/9.0 as dependency. 
-# Moreover apps/r loads tools/gcc/6.4.0 which causes conflict with openmpi/2.0.1-gcc-4.9.2, 
-# thus apps/r (with its dependencies) must be called first $MODULES_ADD, then override with $MODULES_RUN
+# apps/r (with its dependencies) must be called first $MODULES_ADD, then override with $MODULES_RUN
 
 MODULES_ADD_ASK="no"
 MODULES_RUN_ASK="no"

--- a/config
+++ b/config
@@ -122,15 +122,16 @@ then
 fi)
 
 $(test -z "$RHOME" || echo "export PATH=\"$RHOME/bin:\$PATH\"" )
-$(test -z "$MODULES_RUN" || echo "quiet_run module load $MODULES_RUN" )
 
 case "\$TYPE" in
 "MAKE")
 	$(test -z "$MODULES_ADD" || echo "quiet_run module load $MODULES_ADD" )
+	$(test -z "$MODULES_RUN" || echo "quiet_run module load $MODULES_RUN" )
 	$PREPARE_MAKE
 	;;
 "CONFIGURE")
 	$(test -z "$MODULES_ADD" || echo "quiet_run module load $MODULES_ADD" )
+	$(test -z "$MODULES_RUN" || echo "quiet_run module load $MODULES_RUN" )
 	$PREPARE_CONFIGURE
 	;;
 "RUN")

--- a/config
+++ b/config
@@ -135,6 +135,7 @@ case "\$TYPE" in
 	$PREPARE_CONFIGURE
 	;;
 "RUN")
+	$(test -z "$MODULES_RUN" || echo "quiet_run module load $MODULES_RUN" )
 	$PREPARE_RUN
 	;;
 esac


### PR DESCRIPTION
```
[prometheus][plgmuaddieb@login01 GG_TCLB]$ module load apps/cuda/9.0 tools/openmpi/2.0.1-gcc-4.9.2
 apps/cuda/9.0 loaded.
 plgrid/tools/hwloc/1.11.4 loaded.
 plgrid/tools/gcc/4.9.2 loaded.
 tools/openmpi/2.0.1-gcc-4.9.2 loaded.
[prometheus][plgmuaddieb@login01 GG_TCLB]$ module load apps/r
 plgrid/apps/cuda/9.0 loaded.
 plgrid/tools/java8/1.8.0_60 loaded.
 plgrid/tools/gcc/4.9.2 unloaded.
 plgrid/tools/gcc/6.4.0 loaded.
 plgrid/tools/intel/18.0.0 loaded.
 plgrid/tools/impi/2018 loaded.
 plgrid/libs/mkl/2018.0.0 loaded.
 plgrid/libs/jags/4.3.0 loaded.
 plgrid/libs/hdf5/1.8.19 loaded.
 plgrid/libs/netcdf/4.5.0 loaded.
 plgrid/libs/jasper/2.0.14 loaded.
 plgrid/libs/gdal/2.2.2 loaded.
 plgrid/libs/hdf5/1.8.19 unloaded.
 plgrid/libs/netcdf/4.5.0 unloaded.
 plgrid/libs/hdf5/1.8.19 loaded.
 plgrid/libs/netcdf/4.5.0 loaded.
 plgrid/tools/geos/3.6.2 loaded.
 plgrid/tools/unixodbc/2.3.2 loaded.
 plgrid/libs/proj/4.9.1 loaded.
 plgrid/libs/gsl/2.4 loaded.
 apps/r/3.4.4 loaded.

The following have been reloaded with a version change:
  1) plgrid/tools/gcc/4.9.2 => plgrid/tools/gcc/6.4.0
```

same scenario happens in p/config causing it to crash 
(tools/gcc/6.4.0 conflicts with openmpi/2.0.1-gcc-4.9.2):

```
p/config                                                                                                                                                                             
You are on the Prometheus cluster
What is your grant name: clb2018
What is the path to TCLB: /net/people/plgmuaddieb/GG_TCLB
Do you want to run on GPU [y]: y
Provide ./configure options you want to use (please use single ' for quotes): --with-cuda-arch=sm_30
Saving conf... ok
Do you want to install needed R packages now? [n]: n
Do you want to run ./configure now? [y]: y 
salloc: Pending job allocation 12383946
salloc: job 12383946 queued and waiting for resources
salloc: job 12383946 has been allocated resources
salloc: Granted job allocation 12383946
salloc: Waiting for resource configuration
salloc: Nodes p2301 are ready for job
module purge... OK
module load apps/cuda/9.0 tools/openmpi/2.0.1-gcc-4.9.2... OK
module load apps/r... OK
make: `configure' is up to date.
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether mpic++ accepts -g... yes
checking for gcc... mpicc
checking whether we are using the GNU C compiler... yes
checking whether mpicc accepts -g... yes
checking for mpicc option to accept ISO C89... none needed
checking how to run the C++ preprocessor... mpic++ -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yeschecking float.h usability... yes
checking float.h presence... yes
checking malloc.h usability... yes
checking malloc.h presence... yes
checking for malloc.h... yes
checking stddef.h usability... yes
checking stddef.h presence... yes
checking for stddef.h... yes
checking for stdint.h... (cached) yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking wchar.h usability... yes
checking wchar.h presence... yes
checking for wchar.h... yes
checking for sqrt in -lm... yes
checking CUDA home directory... checking for nvcc... yes
using /net/software/local/cuda/9.0
checking for /net/software/local/cuda/9.0/bin/nvcc... yes
checking for /net/software/local/cuda/9.0/lib64/libcudart.so... yes
using CUDALIBDIR:/net/software/local/cuda/9.0/lib64
checking cuda.h usability... yes
checking cuda.h presence... yes
checking for cuda.h... yes
checking target CUDA architecture... sm_30
checking MPI include path... /net/software/local/openmpi/2.0.1-gnu-4.9.2/include
checking MPI library path... /net/software/local/openmpi/2.0.1-gnu-4.9.2/lib
checking mpi.h usability... yes
checking mpi.h presence... yes
checking for mpi.h... yes
checking for MPI_Recv in -lmpi... no
checking for MPI_Recv... no
configure: error: Didn't find MPI Library
srun: error: p2301: task 0: Exited with exit code 1
salloc: Relinquishing job allocation 12383946
```