### PR TITLE
Update prometheus.bash

### DIFF
--- a/cluster/prometheus.bash
+++ b/cluster/prometheus.bash
@@ -13,7 +13,7 @@ function RUN_GPU_CHECK {
 	case "$RUN_GPU" in
 	y)
 		MAINQ_DEF="plgrid-gpu"
-		MODULES_RUN_DEF="plgrid/tools/openmpi/3.0.0-gcc-4.9.2 plgrid/apps/cuda/9.0"
+		MODULES_RUN_DEF="plgrid/apps/r/3.4.4 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 plgrid/apps/cuda/9.0"
 		CONFOPT_DEF="--with-cuda-arch=sm_30"
 		MAX_UNITS_PER_NODE_DEF=2
 		CORES_PER_UNIT_DEF=1
@@ -41,7 +41,7 @@ function RUN_GPU_CHECK {
 }
 MAINQ_ASK="no"
 
-MODULES_ADD_DEF="plgrid/apps/r/3.4.4 -plgrid/apps/cuda"  
+MODULES_ADD_DEF="plgrid/apps/r/3.4.4 plgrid/apps/cuda"  
 # Prometheus's module apps/r loads apps/cuda/9.0 as dependency. 
 # apps/r (with its dependencies) must be called first $MODULES_ADD, then override with $MODULES_RUN
 


### PR DESCRIPTION
to reproduce an error
```.sh
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module purge
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 unloaded.
 plgrid/tools/gcc/4.9.2 unloaded.
 plgrid/tools/java8/1.8.0_60 unloaded.
 plgrid/libs/jags/4.3.0 unloaded.
 plgrid/libs/hdf5/1.8.19 unloaded.
 plgrid/libs/netcdf/4.5.0 unloaded.
 plgrid/libs/jasper/2.0.14 unloaded.
 plgrid/libs/gdal/2.2.2 unloaded.
 plgrid/tools/geos/3.6.2 unloaded.
 plgrid/tools/unixodbc/2.3.2 unloaded.
 plgrid/libs/proj/4.9.1 unloaded.
 plgrid/tools/intel/18.0.0 unloaded.
 plgrid/tools/impi/2018 unloaded.
 plgrid/libs/mkl/2018.0.0 unloaded.
 plgrid/libs/gsl/2.4 unloaded.
 plgrid/apps/r/3.4.4 unloaded.
 plgrid/apps/cuda/9.0 unloaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
 plgrid/tools/gcc/4.9.2 loaded.
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/apps/cuda/9.0 loaded.
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 loaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ 
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 unloaded.
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 loaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/apps/cuda/9.0
 plgrid/apps/cuda/9.0 unloaded.
 plgrid/apps/cuda/9.0 loaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ mpirun -n 2 CLB/d2q9/main example/flow/2d/karman.xml 
[p1735:23584] DONE
CLB/d2q9/main: error while loading shared libraries: libhdf5.so.10: cannot open shared object file: No such file or directory
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
-------------------------------------------------------

```

to fix
```
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module purge
 plgrid/apps/cuda/9.0 unloaded.
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 unloaded.
 plgrid/tools/gcc/4.9.2 unloaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/apps/r/3.4.4
 plgrid/apps/cuda/9.0 loaded.
 plgrid/tools/java8/1.8.0_60 loaded.
 plgrid/tools/gcc/6.4.0 loaded.
 plgrid/tools/intel/18.0.0 loaded.
 plgrid/tools/impi/2018 loaded.
 plgrid/libs/mkl/2018.0.0 loaded.
 plgrid/libs/jags/4.3.0 loaded.
 plgrid/libs/hdf5/1.8.19 loaded.
 plgrid/libs/netcdf/4.5.0 loaded.
 plgrid/libs/jasper/2.0.14 loaded.
 plgrid/libs/gdal/2.2.2 loaded.
 plgrid/libs/hdf5/1.8.19 unloaded.
 plgrid/libs/netcdf/4.5.0 unloaded.
 plgrid/libs/hdf5/1.8.19 loaded.
 plgrid/libs/netcdf/4.5.0 loaded.
 plgrid/tools/geos/3.6.2 loaded.
 plgrid/tools/unixodbc/2.3.2 loaded.
 plgrid/libs/proj/4.9.1 loaded.
 plgrid/libs/gsl/2.4 loaded.
 plgrid/apps/r/3.4.4 loaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
 plgrid/tools/gcc/6.4.0 unloaded.
 plgrid/tools/gcc/4.9.2 loaded.
NVIDIA GPGPU cards available, enable CUDA support for OpenMPI 
 plgrid/tools/openmpi/3.0.0-gcc-4.9.2 loaded.

The following have been reloaded with a version change:
  1) plgrid/tools/gcc/6.4.0 => plgrid/tools/gcc/4.9.2

[prometheus][plgmuaddieb@p1735 GG_TCLB]$ module load plgrid/apps/cuda/9.0
 plgrid/apps/cuda/9.0 unloaded.
 plgrid/apps/cuda/9.0 loaded.
[prometheus][plgmuaddieb@p1735 GG_TCLB]$ mpirun -n 2 CLB/d2q9/main example/flow/2d/karman.xml 
[p1735:23679] DONE
[1573458491.707994] [p1735:23685:0]         shm.c:65   MXM  WARN  Could not open the KNEM device file at /dev/knem : No such file or directory. Won't use knem.
[1573458491.708051] [p1735:23685:0]         mxm.c:196  MXM  WARN  The 'ulimit -s' on the system is set to 'unlimited'. This may have negative performance implications. Please set the stack size to the default value (10240) 
[1573458491.708038] [p1735:23686:0]         shm.c:65   MXM  WARN  Could not open the KNEM device file at /dev/knem : No such file or directory. Won't use knem.
[1573458491.708086] [p1735:23686:0]         mxm.c:196  MXM  WARN  The 'ulimit -s' on the system is set to 'unlimited'. This may have negative performance implications. Please set the stack size to the default value (10240) 
[1573458491.710403] [p1735:23685:0]         shm.c:65   MXM  WARN  Could not open the KNEM device file at /dev/knem : No such file or directory. Won't use knem.
[1573458491.710418] [p1735:23685:0]         mxm.c:196  MXM  WARN  The 'ulimit -s' on the system is set to 'unlimited'. This may have negative performance implications. Please set the stack size to the default value (10240) 
[1573458491.710628] [p1735:23686:0]         shm.c:65   MXM  WARN  Could not open the KNEM device file at /dev/knem : No such file or directory. Won't use knem.
[1573458491.710646] [p1735:23686:0]         mxm.c:196  MXM  WARN  The 'ulimit -s' on the system is set to 'unlimited'. This may have negative performance implications. Please set the stack size to the default value (10240) 
MPMD: TCLB: local:0/2 work:0/2 ---  connected to:
MPMD: TCLB: local:1/2 work:1/2 ---  connected to:
[  ]    #### : -------------------------------------------------------------------------
[  ]    #### : -  CLB version:   v6.0-beta-1483-gdfc0da4                               -
[  ]    #### : -        Model:                      d2q9                               -
[  ]    #### : -------------------------------------------------------------------------
[  ]    #### : Setting output path to: karman
[ 1] warning ! No "Units" element in config file
[ 0] warning ! No "Units" element in config file
[  ]    ==== : Mesh size in config file: 1024x100x1
[  ]    ---- : Global lattice size: 1024x100x1
[  ]    ==== : Max region size: 51200. Mesh size 102400. Overhead:  0%
[  ]    ---- : Local lattice size: 1024x50x1
[  ]    ---- :   Threads  |      Action
[  ]    ---- :    32x16   | Primal , NoGlobals , BaseIteration
[  ]    ---- :    32x16   | Tangent , NoGlobals , BaseIteration
[  ]    ---- :    32x16   | Optimize , NoGlobals , BaseIteration
[  ]    ---- :    32x16   | SteadyAdjoint , NoGlobals , BaseIteration
[  ]    ---- :    32x16   | Primal , IntegrateGlobals , BaseIteration
[  ]    ---- :    32x16   | Tangent , IntegrateGlobals , BaseIteration
[  ]    ---- :    32x16   | Optimize , IntegrateGlobals , BaseIteration
[  ]    ---- :    32x16   | SteadyAdjoint , IntegrateGlobals , BaseIteration
[  ]    ---- :    32x16   | Primal , OnlyObjective , BaseIteration
[  ]    ---- :    32x16   | Tangent , OnlyObjective , BaseIteration
[  ]    ---- :    32x16   | Optimize , OnlyObjective , BaseIteration
[  ]    ---- :    32x16   | SteadyAdjoint , OnlyObjective , BaseIteration
[  ]    ---- :    32x16   | Primal , NoGlobals , BaseInit
[  ]    ---- :    32x16   | Tangent , NoGlobals , BaseInit
[  ]    ---- :    32x16   | Optimize , NoGlobals , BaseInit
[  ]    ---- :    32x16   | SteadyAdjoint , NoGlobals , BaseInit
[  ]    ---- :    32x16   | Primal , IntegrateGlobals , BaseInit
[  ]    ---- :    32x16   | Tangent , IntegrateGlobals , BaseInit
[  ]    ---- :    32x16   | Optimize , IntegrateGlobals , BaseInit
[  ]    ---- :    32x16   | SteadyAdjoint , IntegrateGlobals , BaseInit
[  ]    ---- :    32x16   | Primal , OnlyObjective , BaseInit
[  ]    ---- :    32x16   | Tangent , OnlyObjective , BaseInit
[  ]    ---- :    32x16   | Optimize , OnlyObjective , BaseInit
[  ]    ---- :    32x16   | SteadyAdjoint , OnlyObjective , BaseInit
[  ]    #### : [0] Cumulative allocation of 7476288 b (7.5 MB)
[  ]    ---- : Creating geom size:51200
[  ]    #### : Setting output path to: karman
[  ]    #### : Setting output path to: output/karman
[  ]    ---- : loading geometry ...
[  ]    ---- : Setting number of zones to 3
[  ]    ---- : Setting VelocityX in zone  (-1) to 0.01 (0.010000)
[  ]    ---- : Setting Viscosity to 0.02 (0.020000)
[  ]    ---- : [0] Settings [viscosity] to 0.020000
[  ]    ---- : [0] Settings [one over relaxation time] to 1.785714
[  ]    ---- : [0] Settings [MRT Sx] to -0.785714
[  ]    ---- : Initializing Lattice ...
[  ]    ---- : Setting callback VTK at 1000.000000 iterationss
[  ]    ---- : Adding VTK to the solver hands
[  ]    ---- : Setting action Solve at 10000.000000 iterations
[  ]    ---- :    325.0 MLBUps     47.45 GB/s [====================]
[  ]    ---- :     1000 it writing vtk
[  ]    ---- :    353.2 MLBUps     51.57 GB/s [====================]


```


my (fixed) mods.ini file

``` .sh

TYPE=$1
test -z "$TYPE" && TYPE=MAKE

function quiet_run {
	echo -n "$@... "
	TMPF=$(mktemp)
	if ! $@ >"$TMPF" 2>&1
	then
		echo "ERROR ------";
		cat "$TMPF";
		echo "------- END -------";
		rm "$TMPF";
		exit -1;
	else
		rm "$TMPF";
		echo "OK"
	fi
}

if ! declare -f pb_msg >/dev/null
then
	function pb_msg { return 0; }
	function pb_file { return 0; }
else
	PB_CURL_OPT="--insecure"
fi

function say {
	MSG="$@"
	pb_msg "$SLURM_JOB_NAME" "$MSG (after $SECONDS s)"
}



case "$TYPE" in
"MAKE")
	quiet_run module purge
quiet_run module load plgrid/apps/r/3.4.4
quiet_run module unload plgrid/apps/cuda
quiet_run module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
quiet_run module load plgrid/apps/cuda/9.0
	
	;;
"CONFIGURE")
	quiet_run module purge
quiet_run module load plgrid/apps/r/3.4.4
quiet_run module unload plgrid/apps/cuda
quiet_run module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
quiet_run module load plgrid/apps/cuda/9.0
	
	;;
"RUN")
	quiet_run module purge
	quiet_run module load plgrid/apps/r/3.4.4
	quiet_run module unload plgrid/apps/cuda
	quiet_run module load plgrid/tools/openmpi/3.0.0-gcc-4.9.2
	quiet_run module load plgrid/apps/cuda/9.0
	
	;;
esac
```