### PR TITLE
Passing commandline options to qsub/sbatch

### DIFF
--- a/engine/local.bash
+++ b/engine/local.bash
@@ -51,7 +51,7 @@ function q_batch {
 function q_run {
 	if $ONLY_PRINT
 	then
-		cat $1 | display_scr
+		display_scr "$@"
 	else
 		bash "$@"
 	fi

--- a/engine/pbs.bash
+++ b/engine/pbs.bash
@@ -65,7 +65,7 @@ function q_batch {
 function q_run {
 	if $ONLY_PRINT
 	then
-		cat $1 | display_scr
+		display_scr "$@"
 	else
 		if $RUN_WAIT
 		then

--- a/engine/slurm.bash
+++ b/engine/slurm.bash
@@ -96,7 +96,7 @@ function q_wait {
 function q_run {
 	if $ONLY_PRINT
 	then
-		cat $1 | display_scr
+		display_scr "$@"
 	else
 		JOBID=$(sbatch --parsable "$@")
 		if $RUN_WAIT

--- a/lib.bash
+++ b/lib.bash
@@ -258,8 +258,16 @@ function check_integer {
 }
 
 function display_scr {
+	F="$1"
+	shift
+	while ! test -z "$1"
+	do
+		echo -e "\x1B[32m# Additional command-line option:\x1B[92m $F\x1B[0m"
+		F="$1"
+		shift
+	done
 	echo
-	sed -E -e 's/$/\x1B[0m/' -e 's/^([^#][^#]*)/\x1B[93m\1/' -e 's/(#.*)$/\x1B[32m\1/' -e 's/(#SBATCH|#PBS) /\1 \x1B[92m/'
+	cat "$F" | sed -E -e 's/$/\x1B[0m/' -e 's/^([^#][^#]*)/\x1B[93m\1/' -e 's/(#.*)$/\x1B[32m\1/' -e 's/(#SBATCH|#PBS) /\1 \x1B[92m/'
 	echo
 }
 

--- a/run
+++ b/run
@@ -98,6 +98,11 @@ echo "  MPI ranks: $TASKS"
 echo "    CPU cores per rank: $CORES_PER_TASK"
 echo "    GPUs per rank     : $GPU_PER_TASK"
 echo "    memory per rank   : $MEMORY_PER_TASK"
+if ! test -z "$1"
+then
+	echo "  Options  :" "$@"
+fi
+echo
 
 source_engine $ENGINE
 (
@@ -123,4 +128,4 @@ source_engine $ENGINE
 	echo "$RUN_COMMAND $MPI_OPTS $SINGULARITY_COMMAND $SOLVER $CASE"
 ) >tmp.job.scr
 
-q_run tmp.job.scr
+q_run "$@" "tmp.job.scr"

--- a/run
+++ b/run
@@ -16,6 +16,7 @@ source_conf
 ENGINE="$ENGINE_RUN"
 ONLY_PRINT=false
 RUN_WAIT=false
+TIME="1:00:00"
 for arg
 do
 	shift
@@ -26,6 +27,8 @@ do
 		--local) ENGINE="local" ;;
 		--print) ONLY_PRINT=true;;
 		--wait) RUN_WAIT=true;;
+		--time=*) TIME="${arg#--time=}";;
+		--name=*) NAME="${arg#--name=}";;
 		*) set -- "$@" "$arg";;
 	esac
 done
@@ -83,7 +86,10 @@ fi
 
 CORES=$[$NODES*$TASKS_PER_NODE*$CORES_PER_TASK]
 
-NAME=TCLB:$CASE
+if test -z "$NAME"
+then
+	NAME="TCLB:$CASE"
+fi
 
 GPU_PER_TASK=0
 if test "$RUN_GPU" == "y"
@@ -98,6 +104,7 @@ echo "  MPI ranks: $TASKS"
 echo "    CPU cores per rank: $CORES_PER_TASK"
 echo "    GPUs per rank     : $GPU_PER_TASK"
 echo "    memory per rank   : $MEMORY_PER_TASK"
+echo "  Walltime : $TIME"
 if ! test -z "$1"
 then
 	echo "  Options  :" "$@"
@@ -114,7 +121,7 @@ source_engine $ENGINE
 	q_qos $MAIN_QOS
 	q_units $NODES $TASKS_PER_NODE $CORES_PER_TASK $GPU_PER_TASK
 	q_mem $NODES $TASKS_PER_NODE $MEMORY_PER_TASK
-	q_walltime 01:00:00
+	q_walltime $TIME
 	
 	echo
 	echo "ulimit -l unlimited"


### PR DESCRIPTION
This fixes the passing of options from `run` script to `qsub/sbatch`, and also adds explicit cross-platform options for the job name and time. Also fixes #15 #13 